### PR TITLE
Fix receiving of chunked responses

### DIFF
--- a/lib/krpc/connection.rb
+++ b/lib/krpc/connection.rb
@@ -51,7 +51,7 @@ module KRPC
     
     def send(msg) @socket.send(msg, 0) end
     def recv(maxlen = 1)
-      maxlen == 0 ? "" : @socket.recv(maxlen)
+      maxlen == 0 ? "" : @socket.read(maxlen)
     end
     
     def recv_varint

--- a/lib/krpc/gen.rb
+++ b/lib/krpc/gen.rb
@@ -97,8 +97,8 @@ module KRPC
           TypeStore.get_parameter_type(i, p.type, proc.attributes)
         end
         param_default = proc.parameters.zip(param_types).map do |param, type|
-          if param.has_default_argument
-            Decoder.decode(param.default_argument, type, :clientless)
+          if param.has_default_value
+            Decoder.decode(param.default_value, type, :clientless)
           else :no_default_value
           end
         end

--- a/lib/krpc/krpc.pb.rb
+++ b/lib/krpc/krpc.pb.rb
@@ -48,8 +48,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "krpc.schema.Parameter" do
     optional :name, :string, 1
     optional :type, :string, 2
-    optional :has_default_argument, :bool, 3
-    optional :default_argument, :bytes, 4
+    optional :has_default_value, :bool, 3
+    optional :default_value, :bytes, 4
   end
   add_message "krpc.schema.Class" do
     optional :name, :string, 1


### PR DESCRIPTION
TCP servers may send messages in chunks, but the current implementation assumes that a response is sent in one single message. This is usually fine for localhost connections (where responses are small enough to be sent to local sockets), but connections to hosts on the same network or across the Internet may chunk the response into multiple messages. This change uses `#read` instead of `#recv` which will block and buffer until all bytes are received.

This pull also adds some schema changes that were made to kRPC.